### PR TITLE
Add a few CIS courses from UPenn

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ Courses
   *CUNY Hunter College*
   - This includes the introduction of hashes, heaps, various forms of trees, and graphs. It also revisits recursion and the sorting problem from a higher perspective than was presented in the prequels. On top of this, it is intended to introduce methods of algorithmic analysis.
   - [Lectures and Assignments](http://compsci.hunter.cuny.edu/~sweiss/course_materials/csci335/csci335_s14.php)
-  
+
+### CS Theory
+- [CIS 500](http://www.seas.upenn.edu/~cis500/cis500-f14/index.html) **Software Foundations** *University of Pennsylvania*
+  - An introduction to formal verification of software using the Coq proof assistant. Topics include basic concepts of logic, computer-assisted theorem proving, functional programming, operational semantics, Hoare logic, and static type systems.
+  * [Lectures and Assignments](http://www.seas.upenn.edu/~cis500/cis500-f14/index.html#schedule)
+  - [Textbook](http://www.cis.upenn.edu/~bcpierce/sf/current/index.html)
+
 ### Introduction to CS
 - [CS 50](https://cs50.harvard.edu/) **Introduction to Computer Science** *Harvard University*
   - CS50x is Harvard College's introduction to the intellectual enterprises of computer science and the art of programming for majors and non-majors alike, with or without prior programming experience. An entry-level course taught by David J. Malan.


### PR DESCRIPTION
Namely, I'm adding CIS 581 (computer vision) and CIS 500 (software foundations) to the list.

There was a complaint on the [HN thread](https://news.ycombinator.com/item?id=8806910) that this page didn't have enough theoretical CS courses listed, so I decided to start one with CIS 500. It doesn't really belong in the Algorithms section, and, in my opinion, doesn't really fit nicely with the rest of the courses under Misc.
