### PR TITLE
fix the broken link of CS106B and update the info of CS224n

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,8 +1103,8 @@ Course that uses OCaml to teach functional programming and programming language 
 
 <ul>
 <li>This course is the natural successor to Programming Methodology and covers such advanced programming topics as recursion, algorithmic analysis, and data abstraction using the C++ programming language, which is similar to both C and Java.</li>
-<li><a href="http://see.stanford.edu/see/lecturelist.aspx?coll=11f4f422-5670-4b4c-889c-008262e09e4e">Lectures</a></li>
-<li><a href="http://see.stanford.edu/see/materials/icspacs106b/assignments.aspx">Assignments</a></li>
+<li><a href="https://see.stanford.edu/Course/CS106B/143">Lectures</a></li>
+<li><a href="https://see.stanford.edu/Course/CS106B/">Assignments</a></li>
 <li><a href="http://see.stanford.edu/materials/icspacs106b/ProgrammingAbstractionsAllMaterials.zip">All materials in a zip file</a></li>
 </ul>
 </li>
@@ -1310,12 +1310,14 @@ Course that uses OCaml to teach functional programming and programming language 
 </ul>
 </li>
 <li>
-<a href="http://cs224d.stanford.edu/">CS 224d</a> <strong>Deep Learning for Natural Language Processing</strong> <em>Stanford University</em> <img src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4f9.png" width="20" height="20" alt="Lecture Videos" title="Lecture Videos"> <img src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4bb.png" width="20" height="20" alt="Assignments" title="Assignments"> <img src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4dd.png" width="20" height="20" alt="Lecture Notes" title="Lecture Notes">
+<a href="http://web.stanford.edu/class/cs224n/">CS 224n</a> <strong>Natural Language Processing with Deep Learning</strong> <em>Stanford University</em> <img src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4f9.png" width="20" height="20" alt="Lecture Videos" title="Lecture Videos"> <img src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4bb.png" width="20" height="20" alt="Assignments" title="Assignments"> <img src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4dd.png" width="20" height="20" alt="Lecture Notes" title="Lecture Notes">
 
 <ul>
-<li>Natural language processing (NLP) is one of the most important technologies of the information age. Understanding complex language utterances is also a crucial part of artificial intelligence. Applications of NLP are everywhere because people communicate most everything in language: web search, advertisement, emails, customer service, language translation, radiology reports, etc. There are a large variety of underlying tasks and machine learning models powering NLP applications. Recently, deep learning approaches have obtained very high performance across many different NLP tasks. These models can often be trained with a single end-to-end model and do not require traditional, task-specific feature engineering. In this spring quarter course students will learn to implement, train, debug, visualize and invent their own neural network models. The course provides a deep excursion into cutting-edge research in deep learning applied to NLP.</li>
-<li><a href="http://cs224d.stanford.edu/syllabus.html">Syllabus</a></li>
-<li><a href="http://cs224d.stanford.edu/syllabus.html">Lectures and Assignments</a></li>
+<li>Natural language processing (NLP) is one of the most important technologies of the information age. Understanding complex language utterances is also a crucial part of artificial intelligence. Applications of NLP are everywhere because people communicate most everything in language: web search, advertisement, emails, customer service, language translation, radiology reports, etc. There are a large variety of underlying tasks and machine learning models behind NLP applications. Recently, deep learning approaches have obtained very high performance across many different NLP tasks. These models can often be trained with a single end-to-end model and do not require traditional, task-specific feature engineering. In this winter quarter course students will learn to implement, train, debug, visualize and invent their own neural network models. The course provides a thorough introduction to cutting-edge research in deep learning applied to NLP. On the model side we will cover word vector representations, window-based neural networks, recurrent neural networks, long-short-term-memory models, recursive neural networks, convolutional neural networks as well as some recent models involving a memory component. Through lectures and programming assignments students will learn the necessary engineering tricks for making neural networks work on practical problems.This course is a merger of Stanford's previous cs224n course (Natural Language Processing) and cs224d (Deep Learning for Natural Language Processing). 
+</li>
+<li><a href="http://web.stanford.edu/class/cs224n/syllabus.html">Syllabus</a></li>
+<li><a href="https://www.youtube.com/playlist?list=PL3FW7Lu3i5Jsnh1rnUwq_TcylNr7EkRe6">Lectures</a></li>
+<li><a href="http://web.stanford.edu/class/cs224n/assignments.html">Assignments</a></li>
 </ul>
 </li>
 <li>


### PR DESCRIPTION
The previous link of CS106B is not working and CS224d now merges with previous CS224n to become the new CS224n, 